### PR TITLE
Update to 1.7.0

### DIFF
--- a/libva-intel-driver.spec
+++ b/libva-intel-driver.spec
@@ -1,7 +1,7 @@
 #global _with_gen4asm 1
 
 Name:		libva-intel-driver
-Version:	1.6.2
+Version:	1.7.0
 Release:	1%{?dist}
 Summary:	HW video decode support for Intel integrated graphics
 Group:		System Environment/Libraries
@@ -67,6 +67,9 @@ gendiff . .prebuilt
 
 
 %changelog
+* Sat May 14 2016 Michael Kuhn <suraia@ikkoku.de> - 1.7.0-1
+- Update to 1.7.0.
+
 * Thu Dec 17 2015 Nicolas Chauvet <kwizart@gmail.com> - 1.6.2-1
 - Update to 1.6.2
 


### PR DESCRIPTION
I just updated a few packages for Fedora 24. This PR updates libva-intel-driver to version 1.7.0, which is what F24 is using.
