### PR TITLE
Fix compatibility with mesa 18.3 in F29

### DIFF
--- a/427.patch
+++ b/427.patch
@@ -1,0 +1,65 @@
+From 0abb7a1c938437000bfca1a9b3706884467c681e Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Fri, 7 Dec 2018 13:31:43 +0800
+Subject: [PATCH] Check the interface from libva first
+
+This fixes https://github.com/intel/intel-vaapi-driver/issues/419
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ src/i965_output_wayland.c | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/src/i965_output_wayland.c b/src/i965_output_wayland.c
+index 122db953..a637552e 100644
+--- a/src/i965_output_wayland.c
++++ b/src/i965_output_wayland.c
+@@ -397,6 +397,7 @@ i965_output_wayland_init(VADriverContextP ctx)
+     struct i965_driver_data * const i965 = i965_driver_data(ctx);
+     struct dso_handle *dso_handle;
+     struct wl_vtable *wl_vtable;
++    struct VADriverVTableWayland * const vtable = ctx->vtable_wayland;
+ 
+     static const struct dso_symbol libegl_symbols[] = {
+         {
+@@ -465,25 +466,29 @@ i965_output_wayland_init(VADriverContextP ctx)
+     if (!i965->wl_output)
+         goto error;
+ 
+-    i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME);
+-    if (!i965->wl_output->libegl_handle) {
+-        i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME_FALLBACK);
+-        if (!i965->wl_output->libegl_handle)
++    wl_vtable = &i965->wl_output->vtable;
++
++    if (vtable->wl_interface)
++        wl_vtable->drm_interface = vtable->wl_interface;
++    else {
++        i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME);
++        if (!i965->wl_output->libegl_handle) {
++            i965->wl_output->libegl_handle = dso_open(LIBEGL_NAME_FALLBACK);
++            if (!i965->wl_output->libegl_handle)
++                goto error;
++        }
++
++        dso_handle = i965->wl_output->libegl_handle;
++        if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
++                             libegl_symbols))
+             goto error;
+     }
+ 
+-    dso_handle = i965->wl_output->libegl_handle;
+-    wl_vtable  = &i965->wl_output->vtable;
+-    if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
+-                         libegl_symbols))
+-        goto error;
+-
+     i965->wl_output->libwl_client_handle = dso_open(LIBWAYLAND_CLIENT_NAME);
+     if (!i965->wl_output->libwl_client_handle)
+         goto error;
+ 
+     dso_handle = i965->wl_output->libwl_client_handle;
+-    wl_vtable  = &i965->wl_output->vtable;
+     if (!dso_get_symbols(dso_handle, wl_vtable, sizeof(*wl_vtable),
+                          libwl_client_symbols))
+         goto error;

--- a/libva-intel-driver.spec
+++ b/libva-intel-driver.spec
@@ -10,6 +10,9 @@ Source0:	https://github.com/intel/intel-vaapi-driver/archive/%{version}.tar.gz#/
 Source1:	intel-vaapi-driver.metainfo.xml
 Source9:	parse-intel-vaapi-driver.py
 
+# https://github.com/intel/intel-vaapi-driver/issues/419
+Patch0:		427.patch
+
 ExclusiveArch:	%{ix86} x86_64
 
 BuildRequires:	libtool
@@ -90,6 +93,7 @@ fn=%{buildroot}%{_datadir}/appdata/intel-vaapi-driver.metainfo.xml
 %changelog
 * Wed Feb 13 2019 Pete Walter <pwalter@fedoraproject.org> - 2.3.0-1
 - Update to 2.3.0
+- Backport a patch to fix compatibility with mesa 18.3 in F29
 
 * Thu Oct 11 2018 Nicolas Chauvet <kwizart@gmail.com> - 2.2.0-3
 - Rebuilt for libva update

--- a/libva-intel-driver.spec
+++ b/libva-intel-driver.spec
@@ -1,8 +1,8 @@
 #global _with_gen4asm 1
 
 Name:		libva-intel-driver
-Version:	2.2.0
-Release:	3%{?dist}
+Version:	2.3.0
+Release:	1%{?dist}
 Summary:	HW video decode support for Intel integrated graphics
 License:	MIT and EPL
 URL:		https://01.org/linuxmedia
@@ -88,6 +88,9 @@ fn=%{buildroot}%{_datadir}/appdata/intel-vaapi-driver.metainfo.xml
 
 
 %changelog
+* Wed Feb 13 2019 Pete Walter <pwalter@fedoraproject.org> - 2.3.0-1
+- Update to 2.3.0
+
 * Thu Oct 11 2018 Nicolas Chauvet <kwizart@gmail.com> - 2.2.0-3
 - Rebuilt for libva update
 

--- a/sources
+++ b/sources
@@ -1,1 +1,1 @@
-10b85d0448e47140fe90855ead56b497  libva-intel-driver-2.2.0.tar.gz
+d4fa6426863492066e90c2770819a158  libva-intel-driver-2.3.0.tar.gz


### PR DESCRIPTION
https://bodhi.fedoraproject.org/updates/FEDORA-2019-cefa2d1b59